### PR TITLE
Add table of valid state/territory codes

### DIFF
--- a/documentation/CSV/state_codes.md
+++ b/documentation/CSV/state_codes.md
@@ -1,0 +1,62 @@
+# State/Territory Abbreviations Table
+
+The below table is the list of valid values for the state and territory two-letter abbreviations for the "license_number | [state]" data element header and `state` attribute in the `license_information` object for JSON. In CSV MRFs, the two-letter abbreviation replaces `[state]` in the header in row 1 (e.g., `license_number | AK`).
+
+| State/Territory                              | Valid Values |
+| -------------------------------------------- | ------------ |
+| Alaska                                       | AK           |
+| Alabama                                      | AL           |
+| Arkansas                                     | AR           |
+| American Samoa                               | AS           |
+| Arizona                                      | AZ           |
+| California                                   | CA           |
+| Colorado                                     | CO           |
+| Connecticut                                  | CT           |
+| District of Columbia                         | DC           |
+| Delaware                                     | DE           |
+| Florida                                      | FL           |
+| Georgia                                      | GA           |
+| Guam                                         | GU           |
+| Hawaii                                       | HI           |
+| Iowa                                         | IA           |
+| Idaho                                        | ID           |
+| Illinois                                     | IL           |
+| Indiana                                      | IN           |
+| Kansas                                       | KS           |
+| Kentucky                                     | KY           |
+| Louisiana                                    | LA           |
+| Massachusetts                                | MA           |
+| Maryland                                     | MD           |
+| Maine                                        | ME           |
+| Michigan                                     | MI           |
+| Minnesota                                    | MN           |
+| Missouri                                     | MO           |
+| Commonwealth of the Northern Mariana Islands | MP           |
+| Mississippi                                  | MS           |
+| Montana                                      | MT           |
+| North Carolina                               | NC           |
+| North Dakota                                 | ND           |
+| Nebraska                                     | NE           |
+| New Hampshire                                | NH           |
+| New Jersey                                   | NJ           |
+| New Mexico                                   | NM           |
+| Nevada                                       | NV           |
+| New York                                     | NY           |
+| Ohio                                         | OH           |
+| Oklahoma                                     | OK           |
+| Oregon                                       | OR           |
+| Pennsylvania                                 | PA           |
+| Puerto Rico                                  | PR           |
+| Rhode Island                                 | RI           |
+| South Carolina                               | SC           |
+| South Dakota                                 | SD           |
+| Tennessee                                    | TN           |
+| Texas                                        | TX           |
+| Utah                                         | UT           |
+| Virginia                                     | VA           |
+| U.S. Virgin Islands                          | VI           |
+| Vermont                                      | VT           |
+| Washington                                   | WA           |
+| Wisconsin                                    | WI           |
+| West Virginia                                | WV           |
+| Wyoming                                      | WY           |


### PR DESCRIPTION
These two-letter abbreviations are used in JSON and CSV machine-readable files.